### PR TITLE
v3 - Breaking

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This module allows any primitive to complex value to be proxied in a way that an
 import {
   bound,  // return a function that returns its bound context
   unbound,// if function, invokes it to return the context
-  pair,   // create a `{type, value}` pair to proxy as target
+  target, // create a `{type, value}` pair to proxy as target
   wrap,   // returns array, function, or a pair
   unwrap  // returns the wrapped value
 } from 'proxy-target';
@@ -46,7 +46,7 @@ unwrap(target);
 
 // both wrap and unwrap accept an optional callback
 // the returned value will the one returned by wrap
-target = wrap({a: 1}, (type, value) => pair(type, value));
+target = wrap({a: 1}, (type, value) => target(type, value));
 // {type: "object", value: {a: 1}}
 unwrap(target, (type, value) => value);
 // {a: 1}
@@ -65,7 +65,7 @@ const callbacks = [
 target = wrap(
   callbacks[1],
   (type, value) => bound(
-    pair(type, callbacks.indexOf(value))
+    target(type, callbacks.indexOf(value))
   )
 );
 // function () { return {type: "function", value: 1} );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "proxy-target",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "proxy-target",
-      "version": "2.1.0",
+      "version": "3.0.0",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^15.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proxy-target",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "A wrap/unwrap Proxy utility",
   "main": "./cjs/index.js",
   "scripts": {


### PR DESCRIPTION
This MR defines this module "*done*" for the time being:

  * the `pair` export is now called `target` as it better reflects different exports where *pair* was misleading in the kind of reference to use
  * arrays are now `[value]` instead of `["array", value]` to boost possible serialization bytes
  * functions in `/all` bind just the value, not the pair, as the `type` would be redundant when functions are used as target
  * the internally used `{type, value}` pair is now a `{t, v}` to also boost possible serialization bytes